### PR TITLE
Add FastAPI streaming backend placeholder service

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.pytest_cache/
+.venv/
+.env
+.DS_Store

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY app.py settings.py ./
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8000
+
+WORKDIR /app
+
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /app /app
+
+RUN useradd --create-home appuser
+USER appuser
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,101 @@
+# ChatPage Backend
+
+A minimal FastAPI backend that powers the ChatPage frontend by streaming a placeholder response. The service is ready for local development with Vite as well as containerized deployments.
+
+## Features
+
+- `POST /api/chat` streams plain-text placeholder responses using chunked transfer encoding.
+- `GET /healthz` health check for readiness probes.
+- Strict CORS allowing `http://localhost:5173` during development.
+- Configurable chunk delay, CORS origins, and port via environment variables.
+- Request logging with a generated `X-Request-Id` header.
+- Optional request size guard (10KB message limit).
+
+## Requirements
+
+- Python 3.11+
+- pip
+
+## Setup
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running Locally
+
+```bash
+uvicorn app:app --reload --port 8000
+```
+
+The backend listens on port 8000 by default. Adjust the port with the `PORT` environment variable if needed.
+
+### Vite Proxy Configuration
+
+Point the frontend's `/api` requests to the backend during development by updating `vite.config.ts`:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+})
+```
+
+For production, serve the backend behind the same origin as the frontend using a reverse proxy (e.g., Nginx or your hosting provider).
+
+## Environment Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `8000` | Port used by Uvicorn. |
+| `CORS_ORIGINS` | `http://localhost:5173` | Comma-separated allowed origins. |
+| `LOG_LEVEL` | `info` | Logging level. |
+| `DELAY_MS` | `80` | Delay between streamed chunks in milliseconds. |
+| `MAX_MESSAGE_BYTES` | `10240` | Maximum allowed request message size in bytes. |
+
+## Placeholder Response
+
+Every chat request receives the following streamed placeholder text:
+
+> This is a placeholder response from the backend. Your message was received and the streaming is working. Replace this with real AI output when ready.
+
+Update `PLACEHOLDER_TEXT` in `app.py` when you are ready to integrate real AI output.
+
+## Testing
+
+```bash
+pytest
+```
+
+## Docker
+
+Build and run the production image:
+
+```bash
+cd backend
+docker build -t chat-backend .
+docker run --rm -p 8000:8000 chat-backend
+```
+
+The container runs as a non-root user and exposes port 8000.
+
+## Curl Example
+
+Use `curl` with `-N` to preserve the streaming output:
+
+```bash
+curl -N -X POST http://localhost:8000/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"hello"}'
+```
+
+You should see the placeholder text arrive in small chunks until the stream completes.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,134 @@
+"""FastAPI application providing chat streaming endpoints."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from json import JSONDecodeError
+from typing import AsyncGenerator, Iterable
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from settings import settings
+
+
+logger = logging.getLogger("chat-backend")
+logging.basicConfig(level=settings.log_level.upper())
+
+PLACEHOLDER_TEXT = (
+    "This is a placeholder response from the backend. Your message was received and the "
+    "streaming is working. Replace this with real AI output when ready."
+)
+CHUNK_SIZE = 24
+
+
+def chunk_text(text: str, size: int) -> Iterable[str]:
+    for index in range(0, len(text), size):
+        yield text[index : index + size]
+
+
+def message_too_large(message: str) -> bool:
+    return len(message.encode("utf-8")) > settings.max_message_bytes
+
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origin_list,
+    allow_methods=["POST", "OPTIONS"],
+    allow_headers=["Content-Type"],
+)
+
+
+@app.middleware("http")
+async def add_request_logging(request: Request, call_next):  # type: ignore[override]
+    request_id = str(uuid4())
+    request.state.request_id = request_id
+    logger.info(
+        "request.start",
+        extra={
+            "path": request.url.path,
+            "method": request.method,
+            "client": request.client.host if request.client else None,
+            "request_id": request_id,
+        },
+    )
+    try:
+        response = await call_next(request)
+    except Exception:
+        logger.exception("request.error", extra={"request_id": request_id})
+        raise
+    response.headers["X-Request-Id"] = request_id
+    logger.info(
+        "request.end",
+        extra={
+            "path": request.url.path,
+            "method": request.method,
+            "status_code": response.status_code,
+            "request_id": request_id,
+        },
+    )
+    return response
+
+
+async def stream_placeholder(delay: float) -> AsyncGenerator[str, None]:
+    try:
+        for chunk in chunk_text(PLACEHOLDER_TEXT, CHUNK_SIZE):
+            yield chunk
+            await asyncio.sleep(delay)
+    finally:
+        logger.debug("stream.closed")
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+
+@app.post("/api/chat")
+async def chat_endpoint(request: Request):
+    try:
+        payload = await request.body()
+    except Exception as exc:  # pragma: no cover - unexpected
+        logger.exception("request.body_error")
+        raise HTTPException(status_code=400, detail="Invalid request body") from exc
+
+    if not payload:
+        raise HTTPException(status_code=400, detail="Request body is required")
+
+    try:
+        data = json.loads(payload)
+    except JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON payload") from exc
+
+    message = data.get("message") if isinstance(data, dict) else None
+    if message is None:
+        raise HTTPException(status_code=400, detail="'message' field is required")
+    if not isinstance(message, str):
+        raise HTTPException(status_code=400, detail="'message' must be a string")
+    if not message.strip():
+        raise HTTPException(status_code=400, detail="'message' must not be empty")
+    if message_too_large(message):
+        raise HTTPException(status_code=400, detail="'message' exceeds size limit")
+
+    delay_seconds = max(settings.delay_ms, 0) / 1000
+
+    response = StreamingResponse(
+        stream_placeholder(delay_seconds),
+        media_type="text/plain; charset=utf-8",
+        headers={"Cache-Control": "no-cache"},
+    )
+    return response
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):  # type: ignore[override]
+    detail = exc.detail if isinstance(exc.detail, dict) else {"detail": exc.detail}
+    response = JSONResponse(status_code=exc.status_code, content=detail)
+    if request_id := getattr(request.state, "request_id", None):
+        response.headers.setdefault("X-Request-Id", request_id)
+    return response

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.111
+uvicorn[standard]>=0.30
+pydantic>=2,<3
+httpx>=0.27,<0.28
+pytest>=8,<9
+asgi-lifespan>=2.1,<3

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,50 @@
+"""Application settings module."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import List
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _env_str(name: str, default: str) -> str:
+    return os.getenv(name, default)
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Configuration values loaded from environment variables."""
+
+    port: int
+    cors_origins: str
+    log_level: str
+    delay_ms: int
+    max_message_bytes: int
+
+    @property
+    def cors_origin_list(self) -> List[str]:
+        return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings(
+        port=_env_int("PORT", 8000),
+        cors_origins=_env_str("CORS_ORIGINS", "http://localhost:5173"),
+        log_level=_env_str("LOG_LEVEL", "info"),
+        delay_ms=_env_int("DELAY_MS", 80),
+        max_message_bytes=_env_int("MAX_MESSAGE_BYTES", 10_240),
+    )
+
+
+settings = get_settings()

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+import pytest
+from asgi_lifespan import LifespanManager
+from httpx import AsyncClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import app, PLACEHOLDER_TEXT  # noqa: E402  pylint: disable=wrong-import-position
+
+
+@pytest.mark.anyio
+async def test_healthz():
+    async with LifespanManager(app):
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.anyio
+async def test_chat_streams_placeholder_text():
+    async with LifespanManager(app):
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post("/api/chat", json={"message": "hello"})
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/plain")
+            assert response.headers["cache-control"] == "no-cache"
+            chunks = []
+            async for chunk in response.aiter_text():
+                chunks.append(chunk)
+    body = "".join(chunks)
+    assert PLACEHOLDER_TEXT in body


### PR DESCRIPTION
## Summary
- add a FastAPI application that streams a placeholder response over POST /api/chat and exposes a health check
- configure environment-driven settings, strict CORS, logging, and container packaging assets
- include documentation and pytest coverage for the health check and streaming happy path

## Testing
- pytest *(fails: missing optional dependencies in the execution environment due to blocked package downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68db9b015e5483268e9e20ee8bfb8ef7