### PR TITLE
Add production domains to default CORS configuration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -7,7 +7,7 @@ development with Vite as well as containerized deployments.
 
 - `POST /api/chat` streams plain-text placeholder responses using chunked transfer encoding.
 - `GET /healthz` health check for readiness probes.
-- Strict CORS allowing `http://localhost:5173` during development.
+- Strict CORS allowing the production domains (`https://mksmart.info`, `https://www.mksmart.info`) as well as `http://localhost:5173` during development.
 - Configurable chunk delay, CORS origins, and port via environment variables.
 - Request logging with a generated `X-Request-Id` header.
 - Optional request size guard (10KB message limit).
@@ -58,7 +58,7 @@ For production, serve the backend behind the same origin as the frontend using a
 | Variable | Default | Description |
 | --- | --- | --- |
 | `PORT` | `8000` | Port used by Uvicorn. |
-| `CORS_ORIGINS` | `http://localhost:5173` | Comma-separated allowed origins. |
+| `CORS_ORIGINS` | `http://localhost:5173,https://mksmart.info,https://www.mksmart.info` | Comma-separated allowed origins. |
 | `LOG_LEVEL` | `info` | Logging level. |
 | `DELAY_MS` | `80` | Delay between streamed chunks in milliseconds. |
 | `MAX_MESSAGE_BYTES` | `10240` | Maximum allowed request message size in bytes. |
@@ -113,7 +113,7 @@ sudo mkdir -p /srv/chat-backend
 sudo chown "$(whoami)" /srv/chat-backend
 cat <<'ENVV' > /srv/chat-backend/.env
 PORT=8000
-CORS_ORIGINS=http://localhost:5173
+CORS_ORIGINS=http://localhost:5173,https://mksmart.info,https://www.mksmart.info
 ENVV
 ```
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -38,9 +38,17 @@ class Settings:
 
 @lru_cache
 def get_settings() -> Settings:
+    default_cors_origins = ",".join(
+        (
+            "http://localhost:5173",
+            "https://mksmart.info",
+            "https://www.mksmart.info",
+        )
+    )
+
     return Settings(
         port=_env_int("PORT", 8000),
-        cors_origins=_env_str("CORS_ORIGINS", "http://localhost:5173"),
+        cors_origins=_env_str("CORS_ORIGINS", default_cors_origins),
         log_level=_env_str("LOG_LEVEL", "info"),
         delay_ms=_env_int("DELAY_MS", 80),
         max_message_bytes=_env_int("MAX_MESSAGE_BYTES", 10_240),

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -10,6 +10,11 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from app import app, PLACEHOLDER_TEXT  # noqa: E402  pylint: disable=wrong-import-position
 
 
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
 @pytest.mark.anyio
 async def test_healthz():
     async with LifespanManager(app):


### PR DESCRIPTION
## Summary
- include the deployed mksmart domains in the default CORS origin list
- document the updated defaults and deployment instructions
- pin tests to the asyncio backend to avoid missing trio dependency during test runs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd3a46060c8326a42e808f01caeb2c