### PR TITLE
Add BuildKit cleanup to remote deploy script

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -165,6 +165,17 @@ jobs:
           fi
 
           # 3) Build image using $APP_DIR as context
+          # Enable BuildKit for faster, leaner builds
+          export DOCKER_BUILDKIT=1
+
+          # Clean up space before building
+          sudo docker system prune -af || true
+          sudo docker builder prune -af || true
+
+          # (Optional) sanity checks
+          df -h
+          free -h
+
           sudo docker build --pull -t "$APP_NAME:$TAG" -t "$APP_NAME:latest" "$APP_DIR"
 
           # 4) Restart container


### PR DESCRIPTION
## Summary
- enable Docker BuildKit in the remote deployment script generated by the workflow
- prune unused Docker data and print disk/memory usage before building the image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de886475348326acefbbe917d05962