### PR TITLE
Add root-level /me session endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -105,6 +105,16 @@ async def healthz():
     return {"status": "ok"}
 
 
+@app.get("/me")
+async def me(request: Request):
+    session = getattr(request.state, "session", {})
+    if not isinstance(session, dict):
+        session = {}
+
+    user_id = session.get("user_id")
+    return {"anonymous": user_id is None, "user_id": user_id}
+
+
 @app.post("/api/chat", dependencies=[Depends(require_csrf)])
 async def chat_endpoint(request: Request):
     try:

--- a/backend/tests/test_me.py
+++ b/backend/tests/test_me.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pytest
+from asgi_lifespan import LifespanManager
+from httpx import AsyncClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import app  # noqa: E402  pylint: disable=wrong-import-position
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_me_endpoint_returns_session_information():
+    async with LifespanManager(app):
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.get("/me")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {"anonymous": True, "user_id": None}


### PR DESCRIPTION
## Summary
- expose a GET /me endpoint at the application root that returns session anonymity info
- add an async test ensuring the endpoint responds without CSRF or anti-replay requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de9bc79c1c8326978947824a902ba9