### PR TITLE
Allow credentialed CORS requests for www.mksmart.info

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -44,8 +44,9 @@ register_session_events(app)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origin_list,
-    allow_methods=["POST", "OPTIONS"],
-    allow_headers=["Content-Type"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 app.add_middleware(SessionMiddleware)


### PR DESCRIPTION
## Summary
- enable credentialed CORS support so www.mksmart.info can make authenticated requests
- allow all methods and headers through the CORS middleware to match credentialed access needs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de9d652a1c83269be1b0cff706cedf