### PR TITLE
Add CSRF seed endpoint and update security middleware

### DIFF
--- a/backend/tests/test_csrf.py
+++ b/backend/tests/test_csrf.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from app import app
+from core.csrf import CSRFTOKEN_COOKIE_NAME
+
+
+client = TestClient(app)
+
+
+def test_csrf_seed_sets_cookie_and_allows_frontend_origin():
+    response = client.get("/csrf", headers={"origin": "https://www.mksmart.info"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    token = payload.get("csrf")
+    assert token
+    assert response.cookies.get(CSRFTOKEN_COOKIE_NAME) == token
+    assert (
+        response.headers.get("access-control-allow-origin")
+        == "https://www.mksmart.info"
+    )
+    assert response.headers.get("access-control-allow-credentials") == "true"


### PR DESCRIPTION
## Summary
- expose a /csrf seed endpoint and reorder middleware so CORS runs ahead of anti-replay and session logic
- extend CSRF helpers to persist the token cookie without overwriting route-set values and include a max-age
- add coverage to ensure /csrf returns a token, sets the cookie, and emits the expected CORS headers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de9f26dd448326ab88e2bf05ec4532